### PR TITLE
Update resource_aws_lambda_function.go

### DIFF
--- a/aws/resource_aws_lambda_function.go
+++ b/aws/resource_aws_lambda_function.go
@@ -413,7 +413,7 @@ func resourceAwsLambdaFunctionCreate(d *schema.ResourceData, meta interface{}) e
 
 	d.SetId(d.Get("function_name").(string))
 
-	if reservedConcurrentExecutions > 0 {
+	if reservedConcurrentExecutions >= 0 {
 
 		log.Printf("[DEBUG] Setting Concurrency to %d for the Lambda Function %s", reservedConcurrentExecutions, functionName)
 


### PR DESCRIPTION
This PR addresses the issue here (https://github.com/terraform-providers/terraform-provider-aws/issues/5287) where setting a value of `0` for the `reserved_concurrent_executions` will not properly enable Reserved Concurrency for the Lambda.  